### PR TITLE
Enable lazy loading of images and videos

### DIFF
--- a/jetbrains-tools.html
+++ b/jetbrains-tools.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<!--suppress RequiredAttributes -->
 <html lang="en">
 
 	<head>
@@ -70,7 +71,7 @@
 				<section data-product="resharper">
 					<h2>Enjoy continuous code quality analysis</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/code_analysis.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/code_analysis.png">
 					</p>
 				</section>
 
@@ -78,7 +79,7 @@
 					<h2>Improve your code with quick-fixes</h2>
 					<p>C#, VB.NET, XAML, ASP.NET, HTML, JavaScript, TypeScript, CSS, XML</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/qf_general.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/qf_general.png">
 						<!--TODO Add shortcut callout (Alt+Enter)-->
 					</p>
 				</section>
@@ -86,63 +87,63 @@
 				<section data-product="resharper">
 					<h2>Use a common naming standard</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/qf_naming.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/qf_naming.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Migrate to C# 6 or 7 when you are ready</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/qf_csharp6.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/qf_csharp6.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>See where LINQ can be used</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/qf_linq.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/qf_linq.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Find and prevent possible exceptions</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/qf_invalid_cast.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/qf_invalid_cast.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Detect unused or unreachable code</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/qf_unreachable_code.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/qf_unreachable_code.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Detect potential threading issues</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/qf_lock.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/qf_lock.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Track errors as they appear, solution-wide</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/swa.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/swa.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Instantly find all code issues in any scope</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/inspection_results.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/inspection_results.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Code faster with extended completion</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/completion.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/completion.png">
 						<!--TODO Add shortcut callout (Ctrl+Space)-->
 					</p>
 				</section>
@@ -150,21 +151,21 @@
 				<section data-product="resharper">
 					<h2>Code faster with extended completion</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/completion2.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/completion2.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Generate boilerplate code quickly</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/generate_general.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/generate_general.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Generate boilerplate code quickly</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/generate_override_members.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/generate_override_members.png">
 					</p>
 				</section>
 
@@ -172,14 +173,14 @@
 					<h2>Debug with pleasure</h2>
 					<p>Inline debugging adornments and searchable DataTips</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/debugging_assistance.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/debugging_assistance.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Refactor safely</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/refactor_this.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/refactor_this.png">
 						<!--TODO Add shortcut callout (Ctrl+Shift+R)-->
 					</p>
 				</section>
@@ -187,35 +188,35 @@
 				<section data-product="resharper">
 					<h2>Find and explore code usages</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/find_usages.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/find_usages.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Find and explore code usages</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/go_to_usages.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/go_to_usages.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Jump to any code quickly</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/go_to_symbol.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/go_to_symbol.png">
 					</p>
 				</section>
 
                 <section data-product="resharper">
                     <h2>Find any text in source and textual files</h2>
                     <p>
-                        <img src="img/screenshots/resharper-ultimate/resharper/go_to_word.png">
+                        <img data-src="img/screenshots/resharper-ultimate/resharper/go_to_word.png">
                     </p>
                 </section>
 
 				<section data-product="resharper">
 					<h2>Speed up with contextual navigation</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/navigate_to.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/navigate_to.png">
 					</p>
 				</section>
 
@@ -223,7 +224,7 @@
 					<h2>Navigate between structural pieces of code</h2>
                     <p>like you're tabbing through a web page in a browser</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/tab_navigation.gif">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/tab_navigation.gif">
 					</p>
 				</section>
 
@@ -231,7 +232,7 @@
 					<h2>Enjoy web development</h2>
 					<p>ASP.NET (Core, MVC, Web Forms), HTML(5), JavaScript, TypeScript, Angular, JSON, CSS</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/aspnet.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/aspnet.png">
 						<!--TODO Add shortcut callout (Alt+Enter)-->
 					</p>
 				</section>
@@ -240,7 +241,7 @@
 					<h2>Enjoy XAML development</h2>
 					<p>WPF, Silverlight, Windows Phone, Universal Windows Platform</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/xaml1.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/xaml1.png">
 						<!--TODO Add shortcut callout (Alt+Enter)-->
 					</p>
 				</section>
@@ -249,7 +250,7 @@
 					<h2>Enjoy XAML development</h2>
 					<p>WPF, Silverlight, Windows Phone, Universal Windows Platform</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/xaml2.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/xaml2.png">
 					</p>
 				</section>
 
@@ -257,7 +258,7 @@
 					<h2>Manage and run unit tests</h2>
 					<p>NUnit, MSTest, xUnit, QUnit, Jasmine...</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/unit_test_explorer_default.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/unit_test_explorer_default.png">
 					</p>
 				</section>
 
@@ -265,7 +266,7 @@
 					<h2>Manage and run unit tests</h2>
 					<p>NUnit, MSTest, xUnit, QUnit, Jasmine...</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/unit_test_explorer_categories.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/unit_test_explorer_categories.png">
 					</p>
 				</section>
 
@@ -273,7 +274,7 @@
 					<h2>Manage and run unit tests</h2>
 					<p>NUnit, MSTest, xUnit, QUnit, Jasmine...</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/unit_test_explorer_sessions.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/unit_test_explorer_sessions.png">
 					</p>
 				</section>
 
@@ -281,7 +282,7 @@
 					<h2>Manage and run unit tests</h2>
 					<p>NUnit, MSTest, xUnit, QUnit, Jasmine...</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/unit_tests_context.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/unit_tests_context.png">
 					</p>
 				</section>
 
@@ -289,21 +290,21 @@
 					<h2>Manage and run unit tests</h2>
 					<p>NUnit, MSTest, xUnit, QUnit, Jasmine...</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/unit_test_sessions.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/unit_test_sessions.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Extend ReSharper</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/extensions.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/extensions.png">
 					</p>
 				</section>
 
 				<section data-product="resharper">
 					<h2>Run inspections from the command line</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper/command_line.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper/command_line.png">
 					</p>
 				</section>
 
@@ -325,149 +326,149 @@
 				<section data-product="resharper-cpp">
 					<h2>Design-time code quality analysis</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/code_analysis.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/code_analysis.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Find code issues in project or solution</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/inspection_results.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/inspection_results.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Repair and improve code with quick-fixes</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/qf_redundant_qualifier.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/qf_redundant_qualifier.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Repair and improve code with quick-fixes</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/qf_use_type.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/qf_use_type.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Code faster with smart completion</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/code_completion.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/code_completion.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Transform code with context actions</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/ca_generate_constructor.png">
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/ca_generate_implementation.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/ca_generate_constructor.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/ca_generate_implementation.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Transform code with context actions</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/ca_substitute_typedef.png">
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/ca_merge_nested_if.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/ca_substitute_typedef.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/ca_merge_nested_if.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Refactor safely</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/refactoring_popup.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/refactoring_popup.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Refactor safely</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/refactoring_dialog.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/refactoring_dialog.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Explore usages of any symbol</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/find_usages.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/find_usages.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Explore to-do comments</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/todo_explorer.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/todo_explorer.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Find everything quickly</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/go_to_combos.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/go_to_combos.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Speed up with smart navigation</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/navigate_to.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/navigate_to.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Navigate between template specializations</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/template_specializations.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/template_specializations.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Visually explore hierarchy of types</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/subtypes_hierarchy.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/subtypes_hierarchy.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Visually explore hierarchy of includes</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/includes_hierarchy.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/includes_hierarchy.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Generate boilerplate code</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/generate_popup.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/generate_popup.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Use templates to code faster</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/templates_surround.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/templates_surround.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Reformat code in any scope</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/format_selection.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/format_selection.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Run inspections from the command line</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/command_line_tools.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/command_line_tools.png">
 					</p>
 				</section>
 
 				<section data-product="resharper-cpp">
 					<h2>Test with pleasure</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/resharper-cpp/unit_testing.png">
+						<img data-src="img/screenshots/resharper-ultimate/resharper-cpp/unit_testing.png">
 					</p>
 				</section>
 
@@ -489,28 +490,28 @@
 				<section data-product="dottrace">
 					<h2>Profile various .NET applications</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dottrace/dottrace_home_screen.png">
+						<img data-src="img/screenshots/resharper-ultimate/dottrace/dottrace_home_screen.png">
 					</p>
 				</section>
 
 				<section data-product="dottrace">
 					<h2>Profile remote applications</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dottrace/remote_profiling.png">
+						<img data-src="img/screenshots/resharper-ultimate/dottrace/remote_profiling.png">
 					</p>
 				</section>
 
 				<section data-product="dottrace">
 					<h2>Profile right in Visual Studio</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dottrace/performance_profiler_in_visual_studio.png">
+						<img data-src="img/screenshots/resharper-ultimate/dottrace/performance_profiler_in_visual_studio.png">
 					</p>
 				</section>
 
 				<section data-product="dottrace">
 					<h2>Dive deeper with integrated decompiler</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dottrace/dottrace_decompiled_source.png">
+						<img data-src="img/screenshots/resharper-ultimate/dottrace/dottrace_decompiled_source.png">
 					</p>
 				</section>
 
@@ -518,29 +519,29 @@
 					<h2>Explore profiling results in different views</h2>
 					<p>Call tree, threads tree, hot spots, plain list, ...</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dottrace/call_tree_view.png">
-						<img src="img/screenshots/resharper-ultimate/dottrace/threads_view.png">
+						<img data-src="img/screenshots/resharper-ultimate/dottrace/call_tree_view.png">
+						<img data-src="img/screenshots/resharper-ultimate/dottrace/threads_view.png">
 					</p>
 				</section>
 
 				<section data-product="dottrace">
 					<h2>Profile async calls easily</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dottrace/async_profiling.png">
+						<img data-src="img/screenshots/resharper-ultimate/dottrace/async_profiling.png">
 					</p>
 				</section>
 
 				<section data-product="dottrace">
 					<h2>Discover bottlenecks with Subsystems view</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dottrace/subsystems.png">
+						<img data-src="img/screenshots/resharper-ultimate/dottrace/subsystems.png">
 					</p>
 				</section>
 
 				<section data-product="dottrace">
 					<h2>Compare profiling results</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dottrace/snapshot_comparison.png">
+						<img data-src="img/screenshots/resharper-ultimate/dottrace/snapshot_comparison.png">
 					</p>
 				</section>
 
@@ -548,7 +549,7 @@
 					<h2>Integration with Visual Studio and ReSharper</h2>
 					<p>One-click profiling of current project and unit tests</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dottrace/profile_all_tests.png">
+						<img data-src="img/screenshots/resharper-ultimate/dottrace/profile_all_tests.png">
 					</p>
 				</section>
 
@@ -570,35 +571,35 @@
 				<section data-product="dotcover">
 					<h2>Code coverage of unit tests</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotcover/unit_test_session_with_coverage.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotcover/unit_test_session_with_coverage.png">
 					</p>
 				</section>
 
 				<section data-product="dotcover">
 					<h2>Code coverage of manual test sessions</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotcover/manual_test_coverage.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotcover/manual_test_coverage.png">
 					</p>
 				</section>
 
 				<section data-product="dotcover">
 					<h2>Run unit tests continuously</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotcover/continuous_testing.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotcover/continuous_testing.png">
 					</p>
 				</section>
 
 				<section data-product="dotcover">
 					<h2>Visualize code coverage</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotcover/dotcover_new_highlighting.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotcover/dotcover_new_highlighting.png">
 					</p>
 				</section>
 
 				<section data-product="dotcover">
 					<h2>Navigate to covering tests</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotcover/navigate_to_covering_tests.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotcover/navigate_to_covering_tests.png">
 						<!--TODO Add shortcut callout (Ctrl+Alt+K,T)-->
 					</p>
 				</section>
@@ -607,7 +608,7 @@
 					<h2>Export coverage results</h2>
 					<p>to HTML, XML, or JSON</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotcover/coverage_report.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotcover/coverage_report.png">
 					</p>
 				</section>
 
@@ -630,7 +631,7 @@
 					<h2>Unique user interface</h2>
 					<p>for easy step-by-step memory analysis</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotmemory/dotmemory_ui.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotmemory/dotmemory_ui.png">
 					</p>
 				</section>
 
@@ -638,14 +639,14 @@
 					<h2>Pinpoint memory issues</h2>
 					<p>with automatic inspections</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotmemory/memory_inspections.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotmemory/memory_inspections.png">
 					</p>
 				</section>
 
 				<section data-product="dotmemory">
 					<h2>Analyze memory consumption in real time</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotmemory/real_time_memory_analysis.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotmemory/real_time_memory_analysis.png">
 					</p>
 				</section>
 
@@ -653,7 +654,7 @@
 					<h2>Analyze call stacks</h2>
 					<p>with the icicle chart</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotmemory/icicle_chart.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotmemory/icicle_chart.png">
 					</p>
 				</section>
 
@@ -661,7 +662,7 @@
 					<h2>Analyze dominating objects</h2>
 					<p>with the sunburst diagram</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotmemory/sunburst_diagram.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotmemory/sunburst_diagram.png">
 					</p>
 				</section>
 
@@ -683,14 +684,14 @@
 				<section data-product="dotpeek">
 					<h2>Decompile and explore .NET assemblies</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotpeek/dotpeek_general.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotpeek/dotpeek_general.png">
 					</p>
 				</section>
 
 				<section data-product="dotpeek">
 					<h2>Export assemblies into source projects</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotpeek/export_to_visual_studio.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotpeek/export_to_visual_studio.png">
 					</p>
 				</section>
 
@@ -698,7 +699,7 @@
 					<h2>Navigate and search in decompiled code</h2>
 					<p>like you would do in Visual Studio with ReSharper</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotpeek/find_usages_dotpeek.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotpeek/find_usages_dotpeek.png">
 					</p>
 				</section>
 
@@ -706,7 +707,7 @@
 					<h2>Navigate and search in decompiled code</h2>
 					<p>like you would do in Visual Studio with ReSharper</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotpeek/go_to_everything.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotpeek/go_to_everything.png">
 					</p>
 				</section>
 
@@ -714,21 +715,21 @@
 					<h2>Navigate and search in decompiled code</h2>
 					<p>like you would do in Visual Studio with ReSharper</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotpeek/dotpeek_type_dependency_diagram.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotpeek/dotpeek_type_dependency_diagram.png">
 					</p>
 				</section>
 
 				<section data-product="dotpeek">
 					<h2>Generate PDF files on-the-fly</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotpeek/pdb_generation_dialog.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotpeek/pdb_generation_dialog.png">
 					</p>
 				</section>
 
 				<section data-product="dotpeek">
 					<h2>Generate PDF files on-the-fly</h2>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotpeek/pdb_generation_log.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotpeek/pdb_generation_log.png">
 					</p>
 				</section>
 
@@ -736,7 +737,7 @@
 					<h2>Use dotPeek symbol server</h2>
 					<p>to generate PDB and source files for your debugger</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/dotpeek/symbol_server.png">
+						<img data-src="img/screenshots/resharper-ultimate/dotpeek/symbol_server.png">
 					</p>
 				</section>
 
@@ -744,7 +745,7 @@
                     <h2>Explore metadata of .NET assemblies</h2>
                     <p>right from the Assembly Explorer</p>
                     <p>
-                        <img src="img/screenshots/resharper-ultimate/dotpeek/dotpeek_metadata_viewer.png">
+                        <img data-src="img/screenshots/resharper-ultimate/dotpeek/dotpeek_metadata_viewer.png">
                     </p>
                 </section>
 				<section data-product="dotpeek">
@@ -770,7 +771,7 @@
                     </div>
 
                     <div class="image-col">
-                        <img src="img/screenshots/resharper-ultimate/rider/welcome.png">
+                        <img data-src="img/screenshots/resharper-ultimate/rider/welcome.png">
                     </div>
 				</section>
 
@@ -778,7 +779,7 @@
 					<h2>Alt+Enter to fix or improve code</h2>
 					<p>Rider uses ReSharper's code analysis under the hood</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/rider/alt_enter.png">
+						<img data-src="img/screenshots/resharper-ultimate/rider/alt_enter.png">
 					</p>
 				</section>
 
@@ -786,7 +787,7 @@
 					<h2>Save time when you improve code</h2>
 					<p>Many quick-fixes can be applied in a file, project, or solution</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/rider/quick_fix_remove_redundant_code.png">
+						<img data-src="img/screenshots/resharper-ultimate/rider/quick_fix_remove_redundant_code.png">
 					</p>
 				</section>
 
@@ -794,7 +795,7 @@
 					<h2>Refactor code left and right</h2>
 					<p>Rename, move and extract code, or change hierarchies</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/rider/refactor.png">
+						<img data-src="img/screenshots/resharper-ultimate/rider/refactor.png">
 					</p>
 				</section>
 
@@ -802,7 +803,7 @@
 					<h2>Navigate with Solution Explorer or breadcrumbs</h2>
 					<p>Multiple navigation features to jump around your code base</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/rider/navigation_breadcrumbs.png">
+						<img data-src="img/screenshots/resharper-ultimate/rider/navigation_breadcrumbs.png">
 					</p>
 				</section>
 
@@ -810,7 +811,7 @@
 					<h2>Search everywhere</h2>
 					<p>Find a class, file, or a recently edited item from a single UI</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/rider/search_everywhere.png">
+						<img data-src="img/screenshots/resharper-ultimate/rider/search_everywhere.png">
 					</p>
 				</section>
 
@@ -818,7 +819,7 @@
 					<h2>Debug any .NET application</h2>
 					<p>Debugger supports .NET Framework, .NET Core, Mono, Xamarin, Unity, ASP.NET, and ASP.NET Core</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/rider/debugger.png">
+						<img data-src="img/screenshots/resharper-ultimate/rider/debugger.png">
 					</p>
 				</section>
 
@@ -826,7 +827,7 @@
                     <h2>Run and manage unit tests</h2>
                     <p>Use NUnit or xUnit targeting .NET Framework, .NET Core, or Mono</p>
                     <p>
-                        <img src="img/screenshots/resharper-ultimate/rider/unit_testing.png">
+                        <img data-src="img/screenshots/resharper-ultimate/rider/unit_testing.png">
                     </p>
                 </section>
 
@@ -834,7 +835,7 @@
                     <h2>Work with databases and SQL</h2>
                     <p>Edit and run SQL scripts, connect to SQL Server or a different DBMS</p>
                     <p>
-                        <img src="img/screenshots/resharper-ultimate/rider/database.png">
+						<img data-src="img/screenshots/resharper-ultimate/rider/database.png">
                     </p>
                 </section>
 
@@ -845,7 +846,7 @@
                     </div>
 
                     <div class="image-col">
-                        <img src="img/screenshots/resharper-ultimate/rider/vcs.png">
+                        <img data-src="img/screenshots/resharper-ultimate/rider/vcs.png">
                     </div>
                 </section>
 
@@ -853,7 +854,7 @@
 					<h2>Enter distraction-free mode</h2>
 					<p>You can make Rider look like Notepad but work like a powerful IDE</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/rider/distraction_free_mode.png">
+						<img data-src="img/screenshots/resharper-ultimate/rider/distraction_free_mode.png">
 					</p>
 				</section>
 
@@ -861,7 +862,7 @@
 					<h2>500+ plugins</h2>
 					<p>ReSharper and IntelliJ platform plugins are available in Rider</p>
 					<p>
-						<img src="img/screenshots/resharper-ultimate/rider/plugins.png">
+						<img data-src="img/screenshots/resharper-ultimate/rider/plugins.png">
 					</p>
 				</section>
 
@@ -882,27 +883,27 @@
 
 				<!--<section data-product="clion">-->
 					<!--<h2>Develop and debug audio app with ease</h2>-->
-					<!--<video data-autoplay src="img/screenshots/clion/JUCE_audio_demo.mp4" />-->
+					<!--<video data-autoplay data-src="img/screenshots/clion/JUCE_audio_demo.mp4" />-->
 				<!--</section>-->
 
 				<section data-product="clion">
 					<h2>Get a smart cross-platform IDE <br/>for C and C++</h2>
 					<p>
-						<img src="img/screenshots/clion/cpp_ide-1200.png">
+						<img data-src="img/screenshots/clion/cpp_ide-1200.png">
 					</p>
 				</section>
 
 				<section data-product="clion">
 					<h2>Native C and C++ support, <br/>including modern C++ standards</h2>
 					<p>
-						<img src="img/screenshots/clion/cpp14_auto_return.png">
+						<img data-src="img/screenshots/clion/cpp14_auto_return.png">
 					</p>
 				</section>
 
 				<section data-product="clion">
 					<h2>Works with GCC, Clang <br/> and Microsoft Visual C++ compilers</h2>
 					<p>
-						<img src="img/screenshots/clion/msvc_release1.png">
+						<img data-src="img/screenshots/clion/msvc_release1.png">
 					</p>
 				</section>
 
@@ -910,7 +911,7 @@
 					<h2>Code faster with smart editor</h2>
 					<p>Auto-import</p>
 					<p>
-						<img src="img/screenshots/clion/auto_import-2611.png">
+						<img data-src="img/screenshots/clion/auto_import-2611.png">
 					</p>
 				</section>
 
@@ -918,7 +919,7 @@
 					<h2>Code faster with smart editor</h2>
 					<p>Parameter info</p>
 					<p>
-						<img src="img/screenshots/clion/param_info-1647.png">
+						<img data-src="img/screenshots/clion/param_info-1647.png">
 					</p>
 				</section>
 
@@ -926,7 +927,7 @@
 					<h2>Code faster with smart editor</h2>
 					<p>Live templates & Multiple cursors</p>
 					<p>
-						<img src="img/screenshots/clion/multiple_cursor_templates_compl.gif">
+						<img data-src="img/screenshots/clion/multiple_cursor_templates_compl.gif">
 					</p>
 				</section>
 
@@ -937,7 +938,7 @@
                     </div>
 
                     <div class="image-col">
-                        <img src="img/screenshots/clion/code_styles_predefined.png">
+                        <img data-src="img/screenshots/clion/code_styles_predefined.png">
                     </div>
                 </section>
 
@@ -948,7 +949,7 @@
                     </div>
 
                     <div class="image-col">
-                        <img src="img/screenshots/clion/keymap-1627.png">
+                        <img data-src="img/screenshots/clion/keymap-1627.png">
                     </div>
                 </section>
 
@@ -956,7 +957,7 @@
 					<h2>Read code with ease</h2>
 					<p>Semantic highlighting</p>
 					<p>
-						<img src="img/screenshots/clion/semantic_highlight.png"><br/>
+						<img data-src="img/screenshots/clion/semantic_highlight.png"><br/>
 					</p>
 				</section>
 
@@ -964,7 +965,7 @@
 					<h2>Read code with ease</h2>
 					<p>Resolve context</p>
 					<p>
-						<img src="img/screenshots/clion/resolve_context.gif"><br/>
+						<img data-src="img/screenshots/clion/resolve_context.gif"><br/>
 					</p>
 				</section>
 
@@ -972,7 +973,7 @@
 					<h2>Navigate efficiently</h2>
 					<p>Structure view</p>
 					<p>
-						<img src="img/screenshots/clion/structure_view.png"><br/>
+						<img data-src="img/screenshots/clion/structure_view.png"><br/>
 					</p>
 				</section>
 
@@ -980,7 +981,7 @@
 					<h2>Navigate efficiently</h2>
 					<p>Go to class, file, symbol by its name</p>
 					<p>
-						<img src="img/screenshots/clion/goto_class-1225.png">
+						<img data-src="img/screenshots/clion/goto_class-1225.png">
 					</p>
 				</section>
 
@@ -988,7 +989,7 @@
 					<h2>Navigate efficiently</h2>
 					<p>Hierarchy views</p>
 					<p>
-						<img src="img/screenshots/clion/hierarchy.png">
+						<img data-src="img/screenshots/clion/hierarchy.png">
 					</p>
 				</section>
 
@@ -996,7 +997,7 @@
 					<h2>Code faster with templates</h2>
 					<p>Surround With... templates</p>
 					<p>
-						<img src="img/screenshots/clion/surround_with_if.gif">
+						<img data-src="img/screenshots/clion/surround_with_if.gif">
 					</p>
 				</section>
 
@@ -1004,7 +1005,7 @@
 					<h2>Code faster with templates</h2>
 					<p>Live templates for C, C++, CMake and more</p>
 					<p>
-						<img src="img/screenshots/clion/cmake_boost_live_template.gif">
+						<img data-src="img/screenshots/clion/cmake_boost_live_template.gif">
 					</p>
 				</section>
 
@@ -1012,7 +1013,7 @@
 					<h2>Speed up with code generation</h2>
 					<p>Create from usage</p>
 					<p>
-						<img src="img/screenshots/clion/create_usage-2454.png">
+						<img data-src="img/screenshots/clion/create_usage-2454.png">
 					</p>
 				</section>
 
@@ -1020,7 +1021,7 @@
 					<h2>Speed up with code generation</h2>
 					<p>Generate operators</p>
 					<p>
-						<img src="img/screenshots/clion/generate_operator-2690.png">
+						<img data-src="img/screenshots/clion/generate_operator-2690.png">
 					</p>
 				</section>
 
@@ -1028,7 +1029,7 @@
 					<h2>Speed up with code generation</h2>
 					<p>Override/Implement, and more</p>
 					<p>
-						<img src="img/screenshots/clion/generate_menu-2660.png">
+						<img data-src="img/screenshots/clion/generate_menu-2660.png">
 					</p>
 				</section>
 
@@ -1036,7 +1037,7 @@
 					<h2>Keep a good <code></code> quality</h2>
 					<p>On-the-fly code analysis</p>
 					<p>
-						<img src="img/screenshots/clion/analysis.png">
+						<img data-src="img/screenshots/clion/analysis.png">
 					</p>
 				</section>
 
@@ -1044,7 +1045,7 @@
 					<h2>Keep a good code quality</h2>
 					<p>Quick-fixes</p>
 					<p>
-						<img src="img/screenshots/clion/quick_fix.png">
+						<img data-src="img/screenshots/clion/quick_fix.png">
 					</p>
 				</section>
 
@@ -1052,7 +1053,7 @@
 					<h2>Keep a good code quality</h2>
 					<p>Use modern C++</p>
 					<p>
-						<img src="img/screenshots/clion/cast_operators.gif">
+						<img data-src="img/screenshots/clion/cast_operators.gif">
 					</p>
 				</section>
 
@@ -1060,7 +1061,7 @@
 					<h2>Keep a good code quality</h2>
 					<p>Clang-Tidy integration: C++ Core Guidelines, Modernize, etc. </p>
 					<p>
-						<img src="img/screenshots/clion/cppcoreguidelines.gif">
+						<img data-src="img/screenshots/clion/cppcoreguidelines.gif">
 					</p>
 				</section>
 
@@ -1068,7 +1069,7 @@
 					<h2>Refactor safely</h2>
 					<p>Rename symbol and all its context usages</p>
 					<p>
-						<img src="img/screenshots/clion/doxygen_rename.gif">
+						<img data-src="img/screenshots/clion/doxygen_rename.gif">
 					</p>
 				</section>
 
@@ -1076,7 +1077,7 @@
 					<h2>Refactor safely</h2>
 					<p>Extract Function, Variable, Typedef, Class, etc.</p>
 					<p>
-						<img src="img/screenshots/clion/extract_variable.png">
+						<img data-src="img/screenshots/clion/extract_variable.png">
 					</p>
 				</section>
 
@@ -1087,7 +1088,7 @@
                     </div>
 
                     <div class="image-col">
-                        <img src="img/screenshots/clion/refactor_menu-2243.png">
+                        <img data-src="img/screenshots/clion/refactor_menu-2243.png">
                     </div>
                 </section>
 
@@ -1095,7 +1096,7 @@
 					<h2>Debug with GDB and LLDB</h2>
 					<p>Attach to local process, remote GDB debug</p>
 					<p>
-						<img src="img/screenshots/clion/remote_debug.png">
+						<img data-src="img/screenshots/clion/remote_debug.png">
 					</p>
 				</section>
 
@@ -1103,7 +1104,7 @@
 					<h2>Inspect code with built-in debugger</h2>
 					<p>Variable values right in the editor</p>
 					<p>
-						<img src="img/screenshots/clion/inline_view-2298.png">
+						<img data-src="img/screenshots/clion/inline_view-2298.png">
 					</p>
 				</section>
 
@@ -1111,7 +1112,7 @@
 					<h2>Inspect code with built-in debugger</h2>
 					<p>Watches and Evaluate expressions</p>
 					<p>
-						<img src="img/screenshots/clion/watches-1443.png">
+						<img data-src="img/screenshots/clion/watches-1443.png">
 					</p>
 				</section>
 
@@ -1119,14 +1120,14 @@
 					<h2>Inspect code with built-in debugger</h2>
 					<p>Disassembly view</p>
 					<p>
-						<img src="img/screenshots/clion/force_step_into.gif">
+						<img data-src="img/screenshots/clion/force_step_into.gif">
 					</p>
 				</section>
 
 				<section data-product="clion">
 					<h2>Inspect code with Valgrind Memcheck</h2>
 					<p>
-						<img src="img/screenshots/clion/valgrind.png">
+						<img data-src="img/screenshots/clion/valgrind.png">
 					</p>
 				</section>
 
@@ -1134,7 +1135,7 @@
 					<h2>Cover with unit tests</h2>
 					<p>Google Test, Boost.Test and Catch support</p>
 					<p>
-						<img src="img/screenshots/clion/test_runner.png">
+						<img data-src="img/screenshots/clion/test_runner.png">
 					</p>
 				</section>
 
@@ -1142,7 +1143,7 @@
 					<h2>Cover with unit tests</h2>
 					<p>Code generation for Google Test</p>
 					<p>
-						<img src="img/screenshots/clion/generate_tests.gif">
+						<img data-src="img/screenshots/clion/generate_tests.gif">
 					</p>
 				</section>
 
@@ -1153,7 +1154,7 @@
                     </div>
 
                     <div class="image-col">
-                        <img src="img/screenshots/clion/doxygen_preview.png">
+                        <img data-src="img/screenshots/clion/doxygen_preview.png">
                     </div>
                 </section>
 
@@ -1161,7 +1162,7 @@
 					<h2>Keep your code documented</h2>
 					<p>Completion, Rename refactoring, comments generation</p>
 					<p>
-						<img src="img/screenshots/clion/doxygen_ellipsis_generate.gif">
+						<img data-src="img/screenshots/clion/doxygen_ellipsis_generate.gif">
 					</p>
 				</section>
 
@@ -1172,7 +1173,7 @@
                     </div>
 
                     <div class="image-col">
-                        <img src="img/screenshots/clion/cmake_rename-2762.png">
+                        <img data-src="img/screenshots/clion/cmake_rename-2762.png">
                     </div>
                 </section>
 
@@ -1180,7 +1181,7 @@
 					<h2>Benefit from CMake</h2>
 					<p>Completion</p>
 					<p>
-						<img src="img/screenshots/clion/cmake_completion-2347.png">
+						<img data-src="img/screenshots/clion/cmake_completion-2347.png">
 					</p>
 				</section>
 
@@ -1191,7 +1192,7 @@
                     </div>
 
                     <div class="image-col">
-                        <img src="img/screenshots/clion/new_class-2394.png">
+                        <img data-src="img/screenshots/clion/new_class-2394.png">
                     </div>
                 </section>
 
@@ -1199,7 +1200,7 @@
 					<h2>Benefit from built-in VCS</h2>
 					<p>SVN, Git/GitHub, Mercurial, CVS, Perforce, TFS</p>
 					<p>
-						<img src="img/screenshots/clion/undo_commit.png">
+						<img data-src="img/screenshots/clion/undo_commit.png">
 					</p>
 				</section>
 
@@ -1210,7 +1211,7 @@
                     </div>
 
                     <div class="image-col">
-                        <img src="img/screenshots/clion/local_history.png">
+                        <img data-src="img/screenshots/clion/local_history.png">
                     </div>
                 </section>
 
@@ -1221,7 +1222,7 @@
 					</div>
 
 					<div class="image-col">
-						<img src="img/screenshots/clion/commit_changes.png">
+						<img data-src="img/screenshots/clion/commit_changes.png">
 					</div>
 				</section>
 
@@ -1232,19 +1233,19 @@
 					</div>
 
 					<div class="image-col">
-						<img src="img/screenshots/clion/resolve_conflict.gif">
+						<img data-src="img/screenshots/clion/resolve_conflict.gif">
 					</div>
 				</section>
 
 				<section data-product="clion">
 					<h2>More languages &mdash; more power</h2>
 					<ul class="slide-block">
-						<li><img class="slide-logo" src="img/external_logos/python.svg"></li>
-						<li><img class="slide-logo" src="img/external_logos/swift.svg"></li>
-						<li><img class="slide-logo" src="img/external_logos/javascript.svg"></li>
-						<li><img class="slide-logo" src="img/external_logos/html5.svg"></li>
-						<li><img class="slide-logo" src="img/external_logos/css3.svg"></li>
-						<li><img class="slide-logo" src="img/external_logos/kotlin.svg"></li>
+						<li><img class="slide-logo" data-src="img/external_logos/python.svg"></li>
+						<li><img class="slide-logo" data-src="img/external_logos/swift.svg"></li>
+						<li><img class="slide-logo" data-src="img/external_logos/javascript.svg"></li>
+						<li><img class="slide-logo" data-src="img/external_logos/html5.svg"></li>
+						<li><img class="slide-logo" data-src="img/external_logos/css3.svg"></li>
+						<li><img class="slide-logo" data-src="img/external_logos/kotlin.svg"></li>
 					</ul>
 					<!--TODO consider making images fragments-->
 				</section>
@@ -1277,7 +1278,7 @@
                     <div class="jetbrains-logo _logo-kotlin _size-5"></div>
                 </section>
                 <section data-product="kotlin">
-                    <video class="stretch" data-autoplay src="img/screenshots/kotlin/kotlin.mov" />
+                    <video class="stretch" data-autoplay data-src="img/screenshots/kotlin/kotlin.mov" />
                 </section>
 
 				<!--endregion-->
@@ -1291,230 +1292,230 @@
 				<section data-product="appcode">
 					<h2>Smart editor</h2>
 					<p>Multiple cursors for any language</p>
-						<video data-autoplay src="img/screenshots/appcode/multicursor.mp4" />
+						<video data-autoplay data-src="img/screenshots/appcode/multicursor.mp4" />
 				</section>
 				<section class="high-image-inside" data-product="appcode">
 					<h2>Smart editor</h2>
 					<p>Semantic highlighting</p>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/appcode/semantic@2x.png" />
+						<img class="plain" data-src="img/screenshots/appcode/semantic@2x.png" />
 					</div>
 				</section>
 				<section data-product="appcode">
 					<h2>Smart editor</h2>
 					<p>Inline type hints for Swift</p>
-					<video data-autoplay src="img/screenshots/appcode/type_hints.mp4" />
+					<video data-autoplay data-src="img/screenshots/appcode/type_hints.mp4" />
 				</section>
 				<section class="high-image-inside" data-product="appcode">
 					<h2>Code faster with smart intention actions</h2>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/appcode/intentions.png" />
+						<img class="plain" data-src="img/screenshots/appcode/intentions.png" />
 					</div>
 				</section>
 				<section class="high-image-inside" data-product="appcode">
 					<h2>Code faster with smart intention actions</h2>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/appcode/inspections_swift.png" />
+						<img class="plain" data-src="img/screenshots/appcode/inspections_swift.png" />
 					</div>
 				</section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Code faster with smarter completion</h2>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/completion.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/completion.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Speed up with code generation</h2>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/override_implement.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/override_implement.png"/>
                     </div>
                 </section>
 				<section  data-product="appcode">
 					<h2>Speed up with code generation</h2>
-						<video data-autoplay src="img/screenshots/appcode/generate.mp4"/>
+						<video data-autoplay data-src="img/screenshots/appcode/generate.mp4"/>
 				</section>
 				<section  data-product="appcode">
 					<h2>Speed up with code generation</h2>
-					<video data-autoplay src="img/screenshots/appcode/live_templates.mp4"/>
+					<video data-autoplay data-src="img/screenshots/appcode/live_templates.mp4"/>
 				</section>
 				<section  data-product="appcode">
 					<h2>Speed up with code generation</h2>
-					<video data-autoplay src="img/screenshots/appcode/cfu_1.mp4"/>
+					<video data-autoplay data-src="img/screenshots/appcode/cfu_1.mp4"/>
 				</section>
 				<section  data-product="appcode">
 					<h2>Speed up with code generation</h2>
-					<video data-autoplay src="img/screenshots/appcode/cfu_2.mp4"/>
+					<video data-autoplay data-src="img/screenshots/appcode/cfu_2.mp4"/>
 				</section>
 				<section  data-product="appcode">
 					<h2>Reformat code easily</h2>
-					<video data-autoplay src="img/screenshots/appcode/reformat.mp4"/>
+					<video data-autoplay data-src="img/screenshots/appcode/reformat.mp4"/>
 				</section>
 				<section class="high-image-inside" data-product="appcode">
                     <h2>Improve your code quality</h2>
                     <p>Code inspections for Objective-C, C++ and Swift</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/inspections_c.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/inspections_c.png"/>
                     </div>
                 </section>
                 <section data-product="appcode">
                     <h2>Refactor safely</h2>
                     <p>Rename, extract, or inline anything instantly in <strong>Objective-C/C/C++</strong></p>
-					<video data-autoplay src="img/screenshots/appcode/objc_refactorings.mp4"/>
+					<video data-autoplay data-src="img/screenshots/appcode/objc_refactorings.mp4"/>
 				</section>
 				<section data-product="appcode">
 					<h2>Refactor safely</h2>
 					<p>Rename refactoring for Swift</p>
-					<video data-autoplay src="img/screenshots/appcode/rename_swift.mp4"/>
+					<video data-autoplay data-src="img/screenshots/appcode/rename_swift.mp4"/>
 				</section>
 				<section data-product="appcode">
 					<h2>Refactor safely</h2>
 					<p>Extract Variable refactoring for Swift</p>
-					<video data-autoplay src="img/screenshots/appcode/extract_var_swift.mp4"/>
+					<video data-autoplay data-src="img/screenshots/appcode/extract_var_swift.mp4"/>
 				</section>
 				<section data-product="appcode">
 					<h2>Refactor safely</h2>
 					<p>Extract Method refactoring for Swift</p>
-					<video data-autoplay src="img/screenshots/appcode/extract_method.mp4"/>
+					<video data-autoplay data-src="img/screenshots/appcode/extract_method.mp4"/>
 				</section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Navigate efficiently</h2>
                     <p>Quick navigation options and powerful search</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/navigation_1.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/navigation_1.png"/>
                     </div>
                 </section>
 				<section class="high-image-inside" data-product="appcode">
                     <h2>Navigate efficiently</h2>
                     <p>Quick navigation options and powerful search</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/navigation_2.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/navigation_2.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Search easily</h2>
                     <p>for classes, methods, variables or resources</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/find_usages.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/find_usages.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Multiple perspectives</h2>
                     <p>Import and call hierarchies view &amp; file structure</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/structure.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/structure.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Edit any file under the project root</h2>
                     <p>Files view</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/files_view.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/files_view.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Debug with ease</h2>
                     <p>Evaluate expressions quickly and add watches easily</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/slide012.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/slide012.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Debug with pleasure</h2>
                     <p>View Core Data objects and set any value right in debugger tool window</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/slide013.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/slide013.png"/>
                     </div>
                 </section>
 				<section class="high-image-inside" data-product="appcode">
 					<h2>No-hassle testing</h2>
 					<p>Sort tests by duration</p>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/appcode/sort_by_duration@2x.png"/>
+						<img class="plain" data-src="img/screenshots/appcode/sort_by_duration@2x.png"/>
 					</div>
 				</section>
 				<section class="high-image-inside" data-product="appcode">
 					<h2>No-hassle testing</h2>
 					<p>Re-run only failed tests</p>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/appcode/rerun_failed_tests@2x.png"/>
+						<img class="plain" data-src="img/screenshots/appcode/rerun_failed_tests@2x.png"/>
 					</div>
 				</section>
 				<section class="high-image-inside" data-product="appcode">
 					<h2>No-hassle testing</h2>
 					<p>Benefit from the built-in test history</p>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/appcode/test_history@2x.png"/>
+						<img class="plain" data-src="img/screenshots/appcode/test_history@2x.png"/>
 					</div>
 				</section>
 				<section class="high-image-inside" data-product="appcode" data-autoslide="20000">
 					<h2>No-hassle testing</h2>
 					<p>XCTest, Kiwi, Google Tests, UI tests</p>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/appcode/uitests@2x.gif"/>
+						<img class="plain" data-src="img/screenshots/appcode/uitests@2x.gif"/>
 					</div>
 				</section>
                 <section data-product="appcode">
                     <h2>Document your code in Objective-C</h2>
                     <p>Comments generated automatically</p>
-                    <video  data-autoplay src="img/screenshots/appcode/generate_comments@2x.mp4"/>
+                    <video  data-autoplay data-src="img/screenshots/appcode/generate_comments@2x.mp4"/>
                 </section>
                 <section data-product="appcode">
                     <h2>Document your code in Objective-C</h2>
                     <p>Completion for documentation tags</p>
-                    <video  data-autoplay src="img/screenshots/appcode/param_completion@2x.mp4"/>
+                    <video  data-autoplay data-src="img/screenshots/appcode/param_completion@2x.mp4"/>
                 </section>
                 <section data-product="appcode">
                     <h2>Document your code in Objective-C</h2>
                     <p>Update documentation instantly with <strong>Rename</strong> refactoring</p>
-                    <video  data-autoplay src="img/screenshots/appcode/doc_rename@2x.mp4"/>
+                    <video  data-autoplay data-src="img/screenshots/appcode/doc_rename@2x.mp4"/>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Manage your dependencies directly from the IDE</h2>
                     <p>CocoaPods manager</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/cocoapods.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/cocoapods.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Debug view hierarchies</h2>
                     <p>Reveal integration</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/slide023.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/slide023.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Git, SVN, Mercurial, Perforce</h2>
                     <p>Complete VCS integration</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/vcs.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/vcs.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Save your changes with Local History</h2>
                     <p>even without a version control system</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/slide025.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/slide025.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Use cross-platform frameworks in your iOS app</h2>
                     <p>PhoneGap or React-Native</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/slide026.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/slide026.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Enjoy web development</h2>
                     <p>HTML(5), CSS, JavaScript, Emmet</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/slide027.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/slide027.png"/>
                     </div>
                 </section>
                 <section class="high-image-inside" data-product="appcode">
                     <h2>Customize Environment</h2>
                     <p>Color schemes, Xcode keymap, &amp; VIM emulation</p>
                     <div class="image-col">
-                        <img class="plain" src="img/screenshots/appcode/themes.png"/>
+                        <img class="plain" data-src="img/screenshots/appcode/themes.png"/>
                     </div>
                 </section>
                 <section data-product="appcode">
@@ -1538,7 +1539,7 @@
 					<h2>Smart code completion</h2>
 					<p>Smart completion only suggests types that are expected in the current context</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_overview_7@2x-275.png">
+						<img data-src="img/screenshots/intellij/idea_overview_7@2x-275.png">
 					</p>
 				</section>
 
@@ -1546,7 +1547,7 @@
 					<h2>Framework-specific assistance</h2>
 					<p>Intelligent coding assistance for a large variety of languages: SQL, JPQL, HTML, JavaScript, etc.</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_overview_8@2x-298.png">
+						<img data-src="img/screenshots/intellij/idea_overview_8@2x-298.png">
 					</p>
 				</section>
 
@@ -1554,14 +1555,14 @@
 					<h2>Productivity boosters</h2>
 					<p>The IDE automates the tedious and repetitive development tasks so you can stay focused on the big picture</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_overview_9@2x-319.png">
+						<img data-src="img/screenshots/intellij/idea_overview_9@2x-319.png">
 					</p>
 				</section>
 
 				<section data-product="intellij">
 					<h2>Unbeatable toolset right from the first start</h2>
 					<p>
-						<img src="img/screenshots/intellij/idea_overview_toolset@2.png">
+						<img data-src="img/screenshots/intellij/idea_overview_toolset@2.png">
 					</p>
 				</section>
 
@@ -1569,7 +1570,7 @@
 					<h2>Build tools</h2>
 					<p>Seamless integration with Maven, Gradle, SBT, Grunt, Bower and other build tools</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_maven@2-643.png">
+						<img data-src="img/screenshots/intellij/idea_maven@2-643.png">
 					</p>
 				</section>
 
@@ -1577,7 +1578,7 @@
 					<h2>Version control systems</h2>
 					<p>Unified support for Git, GitHub, SVN, Mercurial, Perforce and other version control systems</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_vcs@2-660.png">
+						<img data-src="img/screenshots/intellij/idea_vcs@2-660.png">
 					</p>
 				</section>
 
@@ -1585,7 +1586,7 @@
 					<h2>Spring &amp; Java EE</h2>
 					<p>Extended coding assistance for Spring and Java EE projects. Seamless integration with enterprise application servers</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_java_ee@2-375.png">
+						<img data-src="img/screenshots/intellij/idea_java_ee@2-375.png">
 					</p>
 				</section>
 
@@ -1593,7 +1594,7 @@
 					<h2>GWT &amp; Vaadin</h2>
 					<p>Native support and advanced coding assistance for developing GWT and Vaadin applications</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_gwt@2-389.png">
+						<img data-src="img/screenshots/intellij/idea_gwt@2-389.png">
 					</p>
 				</section>
 
@@ -1601,7 +1602,7 @@
 					<h2>Grails &amp; Play</h2>
 					<p>An easy choice for any Groovy and Scala project. Advanced support for developing Play and Grails applications</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_grails@2-529.png">
+						<img data-src="img/screenshots/intellij/idea_grails@2-529.png">
 					</p>
 				</section>
 
@@ -1609,7 +1610,7 @@
 					<h2>Android</h2>
 					<p>Android Studio, the official Android IDE by Google, and IntelliJ IDEA share the same IntelliJ platform and core functionality</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_android@2-480.png">
+						<img data-src="img/screenshots/intellij/idea_android@2-480.png">
 					</p>
 				</section>
 
@@ -1617,7 +1618,7 @@
 					<h2>JavaScript &amp; HTML</h2>
 					<p>First-class support for JavaScript, HTML and CSS, as well as their modern successors</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_typescript_react@2-544.png">
+						<img data-src="img/screenshots/intellij/idea_typescript_react@2-544.png">
 					</p>
 				</section>
 
@@ -1625,7 +1626,7 @@
 					<h2>Database tools</h2>
 					<p>Access Oracle, SQL Server, PostgreSQL, MySQL and other databases right from the IDE</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_database@2-625.png">
+						<img data-src="img/screenshots/intellij/idea_database@2-625.png">
 					</p>
 				</section>
 
@@ -1633,7 +1634,7 @@
 					<h2>Plugin ecosystem</h2>
 					<p>IntelliJ IDEA has a robust plugin ecosystem with more than 1500 available plugins</p>
 					<p>
-						<img src="img/screenshots/intellij/idea_plugins@2.png">
+						<img data-src="img/screenshots/intellij/idea_plugins@2.png">
 					</p>
 				</section>
 
@@ -1666,7 +1667,7 @@
 					<h2>Smart completion</h2>
 					<p>Smart completion gives you a list of the most relevant symbols applicable in the current context.</p>
 					<p>
-						<img src="img/screenshots/goland/go_completion_1.png">
+						<img data-src="img/screenshots/goland/go_completion_1.png">
 					</p>
 				</section>
 
@@ -1675,7 +1676,7 @@
 					<p>The IDE offers code completion for the name of a function or field even if the name of its qualifier is not
 						complete.</p>
 					<p>
-						<img src="img/screenshots/goland/go_completion_2.png">
+						<img data-src="img/screenshots/goland/go_completion_2.png">
 					</p>
 				</section>
 
@@ -1683,7 +1684,7 @@
 					<h2>Inspections & quick-fixes</h2>
 					<p>When the IDE finds problematic code, it provides you with quick-fixes which you can apply simply by pressing Alt+Enter.</p>
 					<p>
-						<img src="img/screenshots/goland/go_inspections_1.png">
+						<img data-src="img/screenshots/goland/go_inspections_1.png">
 					</p>
 				</section>
 
@@ -1691,7 +1692,7 @@
 					<h2>Rename and Extract refactorings</h2>
 					<p>The <strong>Rename</strong> and <strong>Extract</strong> refactorings can help you modify your code quickly and safely.</p>
 					<p>
-						<img src="img/screenshots/goland/go_refactorings_1.gif">
+						<img data-src="img/screenshots/goland/go_refactorings_1.gif">
 					</p>
 				</section>
 
@@ -1699,7 +1700,7 @@
 					<h2>Navigation over usages and type hierarchy</h2>
 					<p>It only takes one click to switch to a super function, implementation, usages, declaration, and more.</p>
 					<p>
-						<img src="img/screenshots/goland/go_navigation_1.png">
+						<img data-src="img/screenshots/goland/go_navigation_1.png">
 					</p>
 				</section>
 
@@ -1707,7 +1708,7 @@
 					<h2>Code generation</h2>
 					<p>Often the IDE can generate trivial code for you.</p>
 					<p>
-						<img src="img/screenshots/goland/go_implement_type.gif">
+						<img data-src="img/screenshots/goland/go_implement_type.gif">
 					</p>
 				</section>
 
@@ -1715,7 +1716,7 @@
 					<h2>Detecting recursive calls</h2>
 					<p>If you have a recursive call inside your function, the IDE will detect it and mark it on the gutter.</p>
 					<p>
-						<img src="img/screenshots/goland/go_detecting_recursive_calls.png">
+						<img data-src="img/screenshots/goland/go_detecting_recursive_calls.png">
 					</p>
 				</section>
 
@@ -1723,7 +1724,7 @@
 					<h2>Expression type</h2>
 					<p>The Expression Type action can tell the type of any expression at the caret.</p>
 					<p>
-						<img src="img/screenshots/goland/go_expression_type.png">
+						<img data-src="img/screenshots/goland/go_expression_type.png">
 					</p>
 				</section>
 
@@ -1731,7 +1732,7 @@
 					<h2>Exit points highlighting</h2>
 					<p>The IDE may help you quickly find all return and papartppnic statements within a function.</p>
 					<p>
-						<img src="img/screenshots/goland/go_semantic_highlighting_1.png">
+						<img data-src="img/screenshots/goland/go_semantic_highlighting_1.png">
 					</p>
 				</section>
 
@@ -1739,7 +1740,7 @@
 					<h2>Semantic highlighting</h2>
 					<p>The IDE can use unique colors for each parameter and local variable for better readability.</p>
 					<p>
-						<img src="img/screenshots/goland/go_semantic_highlighting_2.png">
+						<img data-src="img/screenshots/goland/go_semantic_highlighting_2.png">
 					</p>
 				</section>
 
@@ -1747,7 +1748,7 @@
 					<h2>Parameter hints</h2>
 					<p>The IDE shows parameter hints for literals and nils used as function arguments for better readability.</p>
 					<p>
-						<img src="img/screenshots/goland/go_parameter_hints.png">
+						<img data-src="img/screenshots/goland/go_parameter_hints.png">
 					</p>
 				</section>
 
@@ -1755,7 +1756,7 @@
 					<h2>Debugger</h2>
 					<p>The IDE comes with a full-featured debugger.</p>
 					<p>
-						<img src="img/screenshots/goland/go_debugger_1.png">
+						<img data-src="img/screenshots/goland/go_debugger_1.png">
 					</p>
 				</section>
 
@@ -1763,7 +1764,7 @@
 					<h2>Test runner & coverage</h2>
 					<p>The IDE collects the coverage data and displays it in both the aggregated view and per statement in the Editor.</p>
 					<p>
-						<img src="img/screenshots/goland/go_coverage_2.png">
+						<img data-src="img/screenshots/goland/go_coverage_2.png">
 					</p>
 				</section>
 
@@ -1771,7 +1772,7 @@
 					<h2>Version control</h2>
 					<p>The IDE lets you browse the history of changes, manage branches, merge conflicts and much more.</p>
 					<p>
-						<img src="img/screenshots/goland/go_vcs.png">
+						<img data-src="img/screenshots/goland/go_vcs.png">
 					</p>
 				</section>
 
@@ -1780,7 +1781,7 @@
 					<p>The <strong>Type Hierarchy</strong> tool window
 						displays the interfaces implemented by the type at the caret or the types that implement the interface at the caret.</p>
 					<p>
-						<img src="img/screenshots/goland/go_type_hierarchy_up.png">
+						<img data-src="img/screenshots/goland/go_type_hierarchy_up.png">
 					</p>
 				</section>
 
@@ -1788,7 +1789,7 @@
 					<h2>Call Hierarchy</h2>
 					<p>The <strong>Call Hierarchy</strong> tool window displays the tree of function calls inside the function at the caret.</p>
 					<p>
-						<img src="img/screenshots/goland/go_call_hierarchy.png">
+						<img data-src="img/screenshots/goland/go_call_hierarchy.png">
 					</p>
 				</section>
 
@@ -1796,7 +1797,7 @@
 					<h2>Filling structs</h2>
 					<p>The IDE comes with an intention action that can automatically generate the code that initializes a struct at the caret.</p>
 					<p>
-						<img src="img/screenshots/goland/go_fill_struct.gif">
+						<img data-src="img/screenshots/goland/go_fill_struct.gif">
 					</p>
 				</section>
 
@@ -1804,7 +1805,7 @@
 					<h2>Generating getters and setters</h2>
 					<p>The IDE has an intention action that can automatically generate getters and setters for a field at the caret.</p>
 					<p>
-						<img src="img/screenshots/goland/go_getters_setters.gif">
+						<img data-src="img/screenshots/goland/go_getters_setters.gif">
 					</p>
 				</section>
 
@@ -1813,7 +1814,7 @@
 					<p>The <strong>Navigate to Test</strong> action can automatically generate test stubs for a file, package or function. Also, it can navigate
 						you between any function and its test.</p>
 					<p>
-						<img src="img/screenshots/goland/go_navigate_to_test.gif">
+						<img data-src="img/screenshots/goland/go_navigate_to_test.gif">
 					</p>
 				</section>
 
@@ -1821,7 +1822,7 @@
 					<h2>SQL</h2>
 					<p>The IDE offers coding assistance for editing SQL statements within your code.</p>
 					<p>
-						<img src="img/screenshots/goland/go_sql.png">
+						<img data-src="img/screenshots/goland/go_sql.png">
 					</p>
 				</section>
 
@@ -1829,7 +1830,7 @@
 					<h2>Go templates</h2>
 					<p>The IDE provides syntax highlighting and basic coding assistance for editing Go templates.</p>
 					<p>
-						<img src="img/screenshots/goland/go_templates.png">
+						<img data-src="img/screenshots/goland/go_templates.png">
 					</p>
 				</section>
 
@@ -1839,12 +1840,12 @@
 						it prompts to replace them with the extracted symbol. To make the opposite, the IDE offers the
 						<strong>Inline</strong> refactoring.</p>
 					<p>
-						<img src="img/screenshots/goland/go_extract_inline_const.gif">
+						<img data-src="img/screenshots/goland/go_extract_inline_const.gif">
 					</p>
 				</section>
 
 				<!--<section data-product="goland">
-					<video class="stretch" data-autoplay src="img/screenshots/goland	/goland-overview.mp4" />
+					<video class="stretch" data-autoplay data-src="img/screenshots/goland	/goland-overview.mp4" />
 				</section>-->
 
 				<!--endregion-->
@@ -1861,7 +1862,7 @@
                     <h2>Use code completion</h2>
                     <p>based on syntax</p>
                     <p>
-                        <img src="img/screenshots/datagrip/Completion.gif">
+                        <img data-src="img/screenshots/datagrip/Completion.gif">
                     </p>
                 </section>
 
@@ -1869,7 +1870,7 @@
                     <h2>Find usages of objects</h2>
                     <p>in views, stored procedures and functions</p>
                     <p>
-                        <img src="img/screenshots/datagrip/FindUsages.png">
+                        <img data-src="img/screenshots/datagrip/FindUsages.png">
                     </p>
                 </section>
 
@@ -1877,14 +1878,14 @@
                     <h2>Edit multiple table fields</h2>
                     <p>at once!</p>
                     <p>
-                        <img src="img/screenshots/datagrip/SeveralCells.gif">
+                        <img data-src="img/screenshots/datagrip/SeveralCells.gif">
                     </p>
                 </section>
 
                 <section data-product="datagrip">
                     <h2>Import CSV files</h2>
                     <p>
-                        <img src="img/screenshots/datagrip/ImportCSV.png">
+                        <img data-src="img/screenshots/datagrip/ImportCSV.png">
                     </p>
                 </section>
 
@@ -1892,7 +1893,7 @@
                     <h2>Become super-productive</h2>
                     <p>with multiple cursors</p>
                     <p>
-                        <img src="img/screenshots/datagrip/MultiCursors.gif">
+                        <img data-src="img/screenshots/datagrip/MultiCursors.gif">
                     </p>
                 </section>
 
@@ -1900,14 +1901,14 @@
                     <h2>Lost some code?</h2>
                     <p>Use local history of query console</p>
                     <p>
-                        <img src="img/screenshots/datagrip/DiffViwer.png">
+                        <img data-src="img/screenshots/datagrip/DiffViwer.png">
                     </p>
                 </section>
 
                 <section data-product="datagrip" data-autoslide="23000">
                     <h2>Submit changes in bulk</h2>
                     <p>
-                        <img src="img/screenshots/datagrip/Bulk.gif">
+                        <img data-src="img/screenshots/datagrip/Bulk.gif">
                     </p>
                 </section>
 
@@ -1915,7 +1916,7 @@
                     <h2>Get the whole column list</h2>
                     <p>by expanding wildcards</p>
                     <p>
-                        <img src="img/screenshots/datagrip/ExpandWildCard.gif">
+                        <img data-src="img/screenshots/datagrip/ExpandWildCard.gif">
                     </p>
                 </section>
 
@@ -1923,14 +1924,14 @@
                     <h2>Rename objects from code</h2>
                     <p>with a preview of usages in other locations</p>
                     <p>
-                        <img src="img/screenshots/datagrip/Rename.png">
+                        <img data-src="img/screenshots/datagrip/Rename.png">
                     </p>
                 </section>
 
 				<section data-product="datagrip">
 					<h2>Configure execution behavior</h2>
 					<p>
-						<img src="img/screenshots/datagrip/SmartExecute.png">
+						<img data-src="img/screenshots/datagrip/SmartExecute.png">
 					</p>
 				</section>
 
@@ -1938,14 +1939,14 @@
                     <h2>Modify database objects</h2>
                     <p>with DDL script generation</p>
                     <p>
-                        <img src="img/screenshots/datagrip/ModifyTable.png">
+                        <img data-src="img/screenshots/datagrip/ModifyTable.png">
                     </p>
                 </section>
 
                 <section data-product="datagrip">
                     <h2>Compare result sets</h2>
                     <p>
-                        <img src="img/screenshots/datagrip/DiffResults.png">
+                        <img data-src="img/screenshots/datagrip/DiffResults.png">
                     </p>
                 </section>
 
@@ -1953,28 +1954,28 @@
                     <h2>Extract data</h2>
                     <p>to a bunch of UPDATE/INSERT statements</p>
                     <p>
-                        <img src="img/screenshots/datagrip/UpdatesContext.png">
+                        <img data-src="img/screenshots/datagrip/UpdatesContext.png">
                     </p>
                 </section>
 
                 <section data-product="datagrip" data-autoslide="3500">
                     <h2>Here you go!</h2>
                     <p>
-                        <img src="img/screenshots/datagrip/UpdateInsertResults.png">
+                        <img data-src="img/screenshots/datagrip/UpdateInsertResults.png">
                     </p>
                 </section>
 
                 <section data-product="datagrip" data-autoslide="3500">
                     <h2>Extract to JSON</h2>
                     <p>
-                        <img src="img/screenshots/datagrip/JsonResult.png">
+                        <img data-src="img/screenshots/datagrip/JsonResult.png">
                     </p>
                 </section>
 
                 <section data-product="datagrip" data-autoslide="3500">
                     <h2>Extract to XML</h2>
                     <p>
-                        <img src="img/screenshots/datagrip/XMLResult.png">
+                        <img data-src="img/screenshots/datagrip/XMLResult.png">
                     </p>
                 </section>
 
@@ -1982,21 +1983,21 @@
                     <h2>Navigate through data</h2>
                     <p>by foreign keys</p>
                     <p>
-                        <img src="img/screenshots/datagrip/DataNavigation.gif">
+                        <img data-src="img/screenshots/datagrip/DataNavigation.gif">
                     </p>
                 </section>
 
                 <section data-product="datagrip">
                     <h2>Analyze execution plans</h2>
                     <p>
-                        <img src="img/screenshots/datagrip/ExplainPlan.png">
+                        <img data-src="img/screenshots/datagrip/ExplainPlan.png">
                     </p>
                 </section>
 
                 <section data-product="datagrip">
                     <h2>Customize appearance</h2>
                     <p>
-                        <img src="img/screenshots/datagrip/Darcula.png">
+                        <img data-src="img/screenshots/datagrip/Darcula.png">
                     </p>
                 </section>
 
@@ -2004,14 +2005,14 @@
                     <h2>Need to find something?</h2>
                     <p>Search through data and column names</p>
                     <p>
-                        <img src="img/screenshots/datagrip/GridSearch.gif">
+                        <img data-src="img/screenshots/datagrip/GridSearch.gif">
                     </p>
                 </section>
 
                 <section data-product="datagrip">
                     <h2>Execute parametrized queries</h2>
                     <p>
-                        <img src="img/screenshots/datagrip/UsrParams.png">
+                        <img data-src="img/screenshots/datagrip/UsrParams.png">
                     </p>
                 </section>
 
@@ -2035,7 +2036,7 @@
 					<h2>Stay on top of your team's activities</h2>
 						<p>with a live Dashboard</p>
 					<p>
-						<img src="img/screenshots/youtrack/Dashboard.png">
+						<img data-src="img/screenshots/youtrack/Dashboard.png">
 					</p>
 				</section>
 
@@ -2043,7 +2044,7 @@
 					<h2>Find exactly what you need in no time</h2>
 					<p>using smart search queries</p>
 					<p>
-						<img src="img/screenshots/youtrack/Smart_search.png">
+						<img data-src="img/screenshots/youtrack/Smart_search.png">
 					</p>
 				</section>
 
@@ -2051,7 +2052,7 @@
 					<h2>Modify multiple issues at once</h2>
 						<p>using geek-style command window</p>
 					<p>
-						<img src="img/screenshots/youtrack/Commands.png">
+						<img data-src="img/screenshots/youtrack/Commands.png">
 					</p>
 				</section>
 
@@ -2059,7 +2060,7 @@
 					<h2>Keep your hands on the keyboard</h2>
 						<p>Speed up the daily routine with handy shortcuts</p>
 					<p>
-						<img src="img/screenshots/youtrack/Shortcuts.png">
+						<img data-src="img/screenshots/youtrack/Shortcuts.png">
 					</p>
 				</section>
 
@@ -2067,7 +2068,7 @@
 					<h2>Dare to be Agile</h2>
 						<p>Follow Scrum or Kanban</p>
 					<p>
-						<img src="img/screenshots/youtrack/Kanban.png">
+						<img data-src="img/screenshots/youtrack/Kanban.png">
 					</p>
 				</section>
 
@@ -2075,14 +2076,14 @@
 					<h2>Plan sprints and manage backlog</h2>
 					<p>to deliver great products on time</p>
 					<p>
-						<img src="img/screenshots/youtrack/Agile_board.png">
+						<img data-src="img/screenshots/youtrack/Agile_board.png">
 					</p>
 				</section>
 
 				<section data-product="youtrack" data-autoslide="18000">
 					<h2>See updates in real time</h2>
 					<p>
-						<img src="img/screenshots/youtrack/Live_update_new.gif">
+						<img data-src="img/screenshots/youtrack/Live_update_new.gif">
 					</p>
 				</section>
 
@@ -2090,7 +2091,7 @@
 					<h2>Follow your process</h2>
 						<p>Customize issue fields, create your own workflows</p>
 					<p>
-						<img src="img/screenshots/youtrack/Languages.png">
+						<img data-src="img/screenshots/youtrack/Languages.png">
 					</p>
 				</section>
 
@@ -2098,7 +2099,7 @@
 					<h2>YouTrack is comfortably priced</h2>
 						<p>and ready to grow with your company</p>
 					<p>
-						<img src="img/screenshots/youtrack/Payments.png">
+						<img data-src="img/screenshots/youtrack/Payments.png">
 					</p>
 				</section>
 
@@ -2127,7 +2128,7 @@
 						</p>
 					</div>
 					<div class="image-col">
-						<img src="img/screenshots/upsource/automated-workflow-2017.2.png">
+						<img data-src="img/screenshots/upsource/automated-workflow-2017.2.png">
 					</div>
 
 				</section>
@@ -2142,7 +2143,7 @@
 					</div>
 
 					<div class="image-col">
-						<img src="img/screenshots/upsource/2017-2-python.png">
+						<img data-src="img/screenshots/upsource/2017-2-python.png">
 					</div>
 				</section>
 
@@ -2155,7 +2156,7 @@
 						</p>
 					</div>
 					<div class="image-col">
-						<img src="img/screenshots/upsource/progress-tracking.png">
+						<img data-src="img/screenshots/upsource/progress-tracking.png">
 					</div>
 
 				</section>
@@ -2169,7 +2170,7 @@
 						</p>
 					</div>
 					<div class="image-col">
-						<img src="img/screenshots/upsource/UP35-IDEA.png">
+						<img data-src="img/screenshots/upsource/UP35-IDEA.png">
 					</div>
 				</section>
 
@@ -2181,7 +2182,7 @@
 						</p>
 					</div>
 					<div class="image-col">
-						<img src="img/screenshots/upsource/project-treemap.png">
+						<img data-src="img/screenshots/upsource/project-treemap.png">
 					</div>
 				</section>
 
@@ -2193,7 +2194,7 @@
 						</p>
 					</div>
 					<div class="image-col">
-						<img src="img/screenshots/upsource/code-review-chart.png">
+						<img data-src="img/screenshots/upsource/code-review-chart.png">
 					</div>
 				</section>
 
@@ -2205,7 +2206,7 @@
 						</p>
 					</div>
 					<div class="image-col">
-						<img src="img/screenshots/upsource/browseCode.png">
+						<img data-src="img/screenshots/upsource/browseCode.png">
 					</div>
 				</section>
 
@@ -2217,7 +2218,7 @@
 						</p>
 					</div>
 					<div class="image-col">
-						<img src="img/screenshots/upsource/search-updates.png">
+						<img data-src="img/screenshots/upsource/search-updates.png">
 					</div>
 				</section>
 
@@ -2229,7 +2230,7 @@
 						</p>
 					</div>
 					<div class="image-col">
-						<img src="img/screenshots/upsource/connect-to-github.png">
+						<img data-src="img/screenshots/upsource/connect-to-github.png">
 					</div>
 				</section>
 
@@ -2241,7 +2242,7 @@
 						</p>
 					</div>
 					<div class="image-col">
-						<img src="img/screenshots/upsource/scalable_scheme-2.png">
+						<img data-src="img/screenshots/upsource/scalable_scheme-2.png">
 					</div>
 				</section>
 
@@ -2266,7 +2267,7 @@
 				<section data-product="teamcity">
 					<h2>Distributed and concurrent builds</h2>
 					<p>
-						<img src="img/screenshots/teamcity/TeamCity_buildGridSchema.png">
+						<img data-src="img/screenshots/teamcity/TeamCity_buildGridSchema.png">
 					</p>
 				</section>
 
@@ -2274,7 +2275,7 @@
 					<h2>Convenient web interface</h2>
 					<p>Builds and build configurations in Project Overview page</p>
 					<p>
-						<img src="img/screenshots/teamcity/overview.png">
+						<img data-src="img/screenshots/teamcity/overview.png">
 					</p>
 				</section>
 
@@ -2282,7 +2283,7 @@
 					<h2>Convenient web interface</h2>
 					<p>VCS change log with graph for DVCS</p>
 					<p>
-						<img src="img/screenshots/teamcity/changelog.png">
+						<img data-src="img/screenshots/teamcity/changelog.png">
 					</p>
 				</section>
 
@@ -2290,7 +2291,7 @@
 					<h2>Convenient web interface</h2>
 					<p>Personal VCS changes page</p>
 					<p>
-						<img src="img/screenshots/teamcity/my_changes.png">
+						<img data-src="img/screenshots/teamcity/my_changes.png">
 					</p>
 				</section>
 
@@ -2298,7 +2299,7 @@
 					<h2>Convenient web interface</h2>
 					<p>Build results provide quick overview and easy navigation</p>
 					<p>
-						<img src="img/screenshots/teamcity/build_results.png">
+						<img data-src="img/screenshots/teamcity/build_results.png">
 					</p>
 				</section>
 
@@ -2306,7 +2307,7 @@
 					<h2>Advanced VCS integration</h2>
 					<p>Create projects directly from GitHub/Bitbucket repositories</p>
 					<p>
-						<img src="img/screenshots/teamcity/create-projects.png">
+						<img data-src="img/screenshots/teamcity/create-projects.png">
 					</p>
 				</section>
 
@@ -2314,25 +2315,25 @@
 					<h2>Advanced VCS integration</h2>
 					<p>Cross-platform integration with Team Foundation Server</p>
 					<p>
-						<img src="img/screenshots/teamcity/tfs.png">
+						<img data-src="img/screenshots/teamcity/tfs.png">
 					</p>
 				</section>
 
 				<section data-product="teamcity">
 					<!--<h2>Easy project setup</h2>-->
-						<video class="stretch" data-autoplay src="img/screenshots/teamcity/video_easy_setup.mp4" />
+						<video class="stretch" data-autoplay data-src="img/screenshots/teamcity/video_easy_setup.mp4" />
 				</section>
 
 				<section data-product="teamcity">
 					<!--<h2>Keeping the codebase stable with feature branches</h2>-->
-						<video class="stretch" data-autoplay src="img/screenshots/teamcity/video_feature_branches.mp4" />
+						<video class="stretch" data-autoplay data-src="img/screenshots/teamcity/video_feature_branches.mp4" />
 				</section>
 
 				<section data-product="teamcity">
 					<h2>Build chains</h2>
 					<p>Perfect for deployment pipelines</p>
 					<p>
-						<img src="img/screenshots/teamcity/build_chains.png">
+						<img data-src="img/screenshots/teamcity/build_chains.png">
 					</p>
 				</section>
 
@@ -2340,7 +2341,7 @@
 					<h2>Build chains</h2>
 					<p>Complex pipelines with parallel stages</p>
 					<p>
-						<img src="img/screenshots/teamcity/parallel_stages_chain.png">
+						<img data-src="img/screenshots/teamcity/parallel_stages_chain.png">
 					</p>
 				</section>
 
@@ -2352,7 +2353,7 @@
 					</div>
 
 					<div class="image-col">
-						<img src="img/screenshots/teamcity/settings_vcs.png">
+						<img data-src="img/screenshots/teamcity/settings_vcs.png">
 					</div>
 				</section>
 
@@ -2360,7 +2361,7 @@
 					<h2>Infrastructure as code</h2>
 					<p>Create projects and build configurations in code, using Kotlin DSL</p>
 					<p>
-						<img src="img/screenshots/teamcity/kotlin-dsl.png">
+						<img data-src="img/screenshots/teamcity/kotlin-dsl.png">
 					</p>
 				</section>
 
@@ -2368,7 +2369,7 @@
 					<h2>Easy administration and maintenance</h2>
 					<p>Backup, restore, and projects import</p>
 					<p>
-						<img src="img/screenshots/teamcity/project_import.png">
+						<img data-src="img/screenshots/teamcity/project_import.png">
 					</p>
 				</section>
 
@@ -2376,7 +2377,7 @@
 					<h2>Scale big</h2>
 					<p>Connect multiple TeamCity servers for cross-search and instant access to projects</p>
 					<p>
-						<img src="img/screenshots/teamcity/projects-popup.png">
+						<img data-src="img/screenshots/teamcity/projects-popup.png">
 					</p>
 				</section>
 
@@ -2384,29 +2385,29 @@
 					<h2>Scale big</h2>
 					<p>Setup a two-node configuration to reduce load on the main server</p>
 					<p>
-						<img src="img/screenshots/teamcity/two-node-config.jpeg">
+						<img data-src="img/screenshots/teamcity/two-node-config.jpeg">
 					</p>
 				</section>
 
 				<section data-product="teamcity">
 					<h2>Flexible pricing</h2>
 					<p>
-						<img src="img/screenshots/teamcity/pricing.png">
+						<img data-src="img/screenshots/teamcity/pricing.png">
 					</p>
 				</section>
 
 				<section data-product="teamcity">
 					<h2>Trusted by 35,000+ customers</h2>
 					<ul class="slide-block">
-						<li><img class="slide-logo-customers" src="img/external_logos/schlumberger.svg"></li>
-						<li><img class="slide-logo-customers" src="img/external_logos/airbnb.svg"></li>
-						<li><img class="slide-logo-customers" src="img/external_logos/boeing.svg"></li>
-						<li><img class="slide-logo-customers" src="img/external_logos/spacex.svg"></li>
-						<li><img class="slide-logo-customers" src="img/external_logos/teradata.svg"></li>
-						<li><img class="slide-logo-customers" src="img/external_logos/citibank.svg"></li>
-						<li><img class="slide-logo-customers" src="img/external_logos/siemens.svg"></li>
-						<li><img class="slide-logo-customers" src="img/external_logos/wargaming.svg"></li>
-						<li><img class="slide-logo-customers-round" src="img/external_logos/hp.svg"></li>
+						<li><img class="slide-logo-customers" data-src="img/external_logos/schlumberger.svg"></li>
+						<li><img class="slide-logo-customers" data-src="img/external_logos/airbnb.svg"></li>
+						<li><img class="slide-logo-customers" data-src="img/external_logos/boeing.svg"></li>
+						<li><img class="slide-logo-customers" data-src="img/external_logos/spacex.svg"></li>
+						<li><img class="slide-logo-customers" data-src="img/external_logos/teradata.svg"></li>
+						<li><img class="slide-logo-customers" data-src="img/external_logos/citibank.svg"></li>
+						<li><img class="slide-logo-customers" data-src="img/external_logos/siemens.svg"></li>
+						<li><img class="slide-logo-customers" data-src="img/external_logos/wargaming.svg"></li>
+						<li><img class="slide-logo-customers-round" data-src="img/external_logos/hp.svg"></li>
 					</ul>
 				</section>
 
@@ -2429,13 +2430,13 @@
 
 				<section data-product="webstorm">
 					<h2>Be productive with smart code completion</h2>
-					<video class="stretch" data-autoplay src="img/screenshots/webstorm/js-completion.mp4"/>
+					<video class="stretch" data-autoplay data-src="img/screenshots/webstorm/js-completion.mp4"/>
 				</section>
 
 				<section data-product="webstorm">
 					<h2>Efficiently navigate around the project</h2>
 						<video class="stretch" data-autoplay
-							   src="img/screenshots/webstorm/search-everywhere.mov"/>
+							   data-src="img/screenshots/webstorm/search-everywhere.mov"/>
 				</section>
 
 				<section class="high-image-inside"
@@ -2443,79 +2444,79 @@
 					<h2>Avoid errors, thanks to built-in inspections</h2>
 					<div class="image-col">
 						<img class="plain"
-							 src="img/screenshots/webstorm/inspection-missing-module.png">
+							 data-src="img/screenshots/webstorm/inspection-missing-module.png">
 					</div>
 				</section>
 
 				<section class="high-image-inside" data-product="webstorm">
 					<h2>And quicky fix them</h2>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/webstorm/quick-fix-missing-module.png">
+						<img class="plain" data-src="img/screenshots/webstorm/quick-fix-missing-module.png">
 					</div>
 				</section>
 
 				<section data-product="webstorm">
 					<h2>Inspection and quick-fixes can help migrating the code to ES6</h2>
 					<video class="stretch" data-autoplay
-						   src="img/screenshots/webstorm/migrating-to-es6.mov"/>
+						   data-src="img/screenshots/webstorm/migrating-to-es6.mov"/>
 				</section>
 
 				<section class="high-image-inside" data-product="webstorm">
 					<h2>See errors from linters as you type</h2>
 					<p>ESLint, Flow, TSLint, JSCS, JSHint, Stylelint</p>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/webstorm/eslint.png">
+						<img class="plain" data-src="img/screenshots/webstorm/eslint.png">
 					</div>
 				</section>
 
 				<section data-product="webstorm">
 					<h2>Enjoy full technology support</h2>
                     <ul class="slide-block">
-                        <li><img class="slide-logo-small" src="img/external_logos/javascript.svg"></li>
-                        <li><img class="slide-logo-small" src="img/external_logos/css3.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/html5.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/typescript.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/dart.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/flow.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/ecmascript6.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/less.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/sass.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/react.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/angularjs-notext.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/vuejs.svg" alt=""></li>
-						<li><img class="slide-logo-small" src="img/external_logos/nodejs.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/jest.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/ionic.svg"></li>
+                        <li><img class="slide-logo-small" data-src="img/external_logos/javascript.svg"></li>
+                        <li><img class="slide-logo-small" data-src="img/external_logos/css3.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/html5.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/typescript.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/dart.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/flow.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/ecmascript6.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/less.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/sass.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/react.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/angularjs-notext.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/vuejs.svg" alt=""></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/nodejs.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/jest.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/ionic.svg"></li>
 					</ul>
 				</section>
 
 				<section data-product="webstorm">
 					<h2>Refactor the code and don't worry about breaking it</h2>
 					<video class="stretch" data-autoplay
-						   src="img/screenshots/webstorm/refactor-rename.mov"/>
+						   data-src="img/screenshots/webstorm/refactor-rename.mov"/>
 				</section>
 
 				<section data-product="webstorm">
 					<h2>Use completion for React components and properties</h2>
-					<video class="stretch" data-autoplay src="img/screenshots/webstorm/react-completion.mp4"/>
+					<video class="stretch" data-autoplay data-src="img/screenshots/webstorm/react-completion.mp4"/>
 				</section>
 
 				<section data-product="webstorm">
 					<h2>Develop Angular apps with ease: completion in TypeScript files</h2>
 					<video class="stretch" data-autoplay
-							   src="img/screenshots/webstorm/ng2-completion.mov"/>
+						   data-src="img/screenshots/webstorm/ng2-completion.mov"/>
 				</section>
 
 				<section data-product="webstorm">
 					<h2>Develop apps with Vue.js using the power of the IDE</h2>
 					<video class="stretch" data-autoplay
-						   src="img/screenshots/webstorm/vue.mov"/>
+						   data-src="img/screenshots/webstorm/vue.mov"/>
 				</section>
 
 				<section class="high-image-inside" data-product="webstorm">
 					<h2>Commit, review diffs and merge conflicts in the IDE</h2>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/webstorm/vcs-diff.png">
+						<img class="plain" data-src="img/screenshots/webstorm/vcs-diff.png">
 					</div>
 				</section>
 
@@ -2524,7 +2525,7 @@
 					<h2>Debug Node.js apps right in WebStorm</h2>
 					<div class="image-col">
 						<img class="plain"
-							 src="img/screenshots/webstorm/debug-node.png">
+							 data-src="img/screenshots/webstorm/debug-node.png">
 					</div>
 				</section>
 
@@ -2561,7 +2562,7 @@
 				<section data-product="rubymine">
 					<h2>Code faster with code completion</h2>
 					<p>
-						<img src="img/screenshots/rubymine/code_faster_with_code_completion.png"
+						<img data-src="img/screenshots/rubymine/code_faster_with_code_completion.png"
 							 >
 					</p>
 					<p>Code completion: <code style="background-color: lightgray">⌃Space/Ctrl+Space</code></p>
@@ -2572,9 +2573,9 @@
 					<h2>Boost your productivity with a smart editor</h2>
 					<p>Code snippets, inline regexp checking, simultaneous tag editing, etc.</p>
 					<p>
-						<img src="img/screenshots/rubymine/boost_your_productivity_with_editor_1.png"
+						<img data-src="img/screenshots/rubymine/boost_your_productivity_with_editor_1.png"
 							 >
-						<img src="img/screenshots/rubymine/boost_your_productivity_with_editor_2.png"
+						<img data-src="img/screenshots/rubymine/boost_your_productivity_with_editor_2.png"
 							 >
 					</p>
 				</section>
@@ -2582,9 +2583,9 @@
 				<section data-product="rubymine">
 					<h2>Code in many places simultaneously</h2>
 					<p>
-						<img src="img/screenshots/rubymine/code_in_many_places_simultaneously_1.png"
+						<img data-src="img/screenshots/rubymine/code_in_many_places_simultaneously_1.png"
 							 >
-						<img src="img/screenshots/rubymine/code_in_many_places_simultaneously_2.png"
+						<img data-src="img/screenshots/rubymine/code_in_many_places_simultaneously_2.png"
 						>
 					</p>
 				</section>
@@ -2592,7 +2593,7 @@
 				<section data-product="rubymine">
 					<h2>Split the editor horizontally or vertically</h2>
 					<p>
-						<img src="img/screenshots/rubymine/split_editor_horizontally_vertically_cut.png"
+						<img data-src="img/screenshots/rubymine/split_editor_horizontally_vertically_cut.png"
 							 >
 					</p>
 					<p><code>Context menu | Split Vertically</code></p>
@@ -2601,7 +2602,7 @@
 				<section data-product="rubymine">
 					<h2>Fully focus on your code</h2>
 					<p>
-						<img src="img/screenshots/rubymine/fully_focus_on_your_code.png"
+						<img data-src="img/screenshots/rubymine/fully_focus_on_your_code.png"
 							 >
 					</p>
 					<p><code>View | Enter Distraction Free Mode</code></p>
@@ -2612,7 +2613,7 @@
 					<h2>Customize your environment</h2>
 					<p>Color schemes, Vim emulation, TextMate keymap</p>
 					<p>
-						<img src="img/screenshots/rubymine/customize_environment.png"
+						<img data-src="img/screenshots/rubymine/customize_environment.png"
 							 >
 					<p ><code>Preferences | Keymap</code></p>
 				</section>
@@ -2620,7 +2621,7 @@
 				<section data-product="rubymine">
 					<h2>Enjoy the native dark UI theme</h2>
 					<p>
-						<img src="img/screenshots/rubymine/enjoy_dark_native_ui_theme.png"
+						<img data-src="img/screenshots/rubymine/enjoy_dark_native_ui_theme.png"
 							 style="box-shadow: none">
 					</p>
 					<p><code>Ctrl+Backquote | Look and Feel | Darcula</code></p>
@@ -2631,7 +2632,7 @@
 					<h2>Speed up with smart Rails navigation</h2>
 					<p>Take advantage of the convenient Rails project view</p>
 					<p>
-						<img src="img/screenshots/rubymine/speed_up_with_smart_Rails_navigation.png"
+						<img data-src="img/screenshots/rubymine/speed_up_with_smart_Rails_navigation.png"
 							 >
 					</p>
 				</section>
@@ -2639,7 +2640,7 @@
 				<section data-product="rubymine">
 					<h2>View & manage model/class/gem dependencies</h2>
 					<p>
-						<img src="img/screenshots/rubymine/view_manage_dependencies.png"
+						<img data-src="img/screenshots/rubymine/view_manage_dependencies.png"
 							 >
 					</p>
 					<p><code style="background-color: lightgray">⌥⌘U/Alt+Ctrl+U</code></p>
@@ -2649,7 +2650,7 @@
 					<h2>Find code usages</h2>
 					<p>for a class, method, variable, etc.</p>
 					<p>
-						<img src="img/screenshots/rubymine/find_code_usages.png"
+						<img data-src="img/screenshots/rubymine/find_code_usages.png"
 							 >
 					</p>
 					<p><code style="background-color: lightgray">⌥F7/Alt+F7</code></p>
@@ -2659,7 +2660,7 @@
 					<h2>Improve your code with quick fixes</h2>
 					<p>Ruby, Rails, JS, CoffeeScript, HTML, HAML, CSS, SCSS, LESS, Sass, YAML</p>
 					<p>
-						<img src="img/screenshots/rubymine/improve_code_with_quick_fixes.png"
+						<img data-src="img/screenshots/rubymine/improve_code_with_quick_fixes.png"
 							 >
 					</p>
 					<p><code style="background-color: lightgray">⌥↩/Alt+Enter</code></p>
@@ -2667,7 +2668,7 @@
 				<section data-product="rubymine">
 					<h2>Refactor safely</h2>
 					<p>
-						<img src="img/screenshots/rubymine/refactor_safely.png"
+						<img data-src="img/screenshots/rubymine/refactor_safely.png"
 							 style="box-shadow: none">
 					</p>
 					<p><code style="background-color: lightgray">⌃T/Ctrl+Alt+Shift+T</code></p>
@@ -2677,7 +2678,7 @@
 					<h2>Inspect your code</h2>
 					<p>Inspired by Ruby Style Guide, Roodi, Reek, RoR Code Quality Checklist</p>
 					<p>
-						<img src="img/screenshots/rubymine/code_inspection.png"
+						<img data-src="img/screenshots/rubymine/code_inspection.png"
 							 >
 					</p>
 					<p><code>Code | Inspect Code</code></p>
@@ -2686,7 +2687,7 @@
 				<section data-product="rubymine">
 					<h2>Use Bundler, RVM, Rake</h2>
 					<p>
-						<img src="img/screenshots/rubymine/use_bundler_rvm_rake.png"
+						<img data-src="img/screenshots/rubymine/use_bundler_rvm_rake.png"
 						>
 
 					</p>
@@ -2697,7 +2698,7 @@
 					<h2>Run scripts without leaving the IDE </h2>
 					<p>Rails, IRB, SSH consoles, and local terminal</p>
 					<p>
-						<img src="img/screenshots/rubymine/run_scripts.png"
+						<img data-src="img/screenshots/rubymine/run_scripts.png"
 							 >
 					</p>
 					<p><code style="background-color: lightgray">⌥F12/Alt+F12</code></p>
@@ -2707,7 +2708,7 @@
 					<h2>Enjoy complete VCS integration</h2>
 					<p>Git, SVN, Mercurial, Perforce, CVS</p>
 					<p>
-						<img src="img/screenshots/rubymine/vcs.png"
+						<img data-src="img/screenshots/rubymine/vcs.png"
 							 >
 					</p>
 					<p><code style="background-color: lightgray">⌘9/Alt+9</code></p>
@@ -2717,7 +2718,7 @@
 					<h2>Test with pleasure</h2>
 					<p>RSpec, MiniTest, Test::Unit, Cucumber, Shoulda</p>
 					<p>
-						<img src="img/screenshots/rubymine/test_with_pleasure.png"
+						<img data-src="img/screenshots/rubymine/test_with_pleasure.png"
 							 >
 					</p>
 					<p><code>Run | Run test / All tests in: ...</code></p>
@@ -2727,7 +2728,7 @@
 					<h2>Hunt down code flaws with debugger</h2>
 					<p>Ruby, Rails, JavaScript, CoffeeScript, RubyMotion</p>
 					<p>
-						<img src="img/screenshots/rubymine/hunt_down_code_flaws_with_debugger.png"
+						<img data-src="img/screenshots/rubymine/hunt_down_code_flaws_with_debugger.png"
 							 >
 					</p>
 					<p><code style="background-color: lightgray">⌃D/Shift+F9</code></p>
@@ -2737,7 +2738,7 @@
 					<h2>Enjoy web development</h2>
 					<p>HTML(5), HAML, LESS, SCSS, Sass, JavaScript, TypeScript, CoffeeScript, React, Angular 2</p>
 					<p>
-						<img src="img/screenshots/rubymine/enjoy_web_development.png"
+						<img data-src="img/screenshots/rubymine/enjoy_web_development.png"
 							 >
 					</p>
 				</section>
@@ -2746,7 +2747,7 @@
 					<h2>Manage your infrastructure</h2>
 					<p>Deployment with FTP or SFTP, Vagrant, Capistrano, Chef, Puppet</p>
 					<p>
-						<img src="img/screenshots/rubymine/manage_infrastructure_1.png"
+						<img data-src="img/screenshots/rubymine/manage_infrastructure_1.png"
 							 >
 					</p>
 				</section>
@@ -2754,7 +2755,7 @@
 				<section data-product="rubymine">
 					<h2>Runs on all major OSes</h2>
 					<p>
-						<img src="img/screenshots/rubymine/run_on_all_major_OSes_1.png"
+						<img data-src="img/screenshots/rubymine/run_on_all_major_OSes_1.png"
 							 style="box-shadow: none" >
 					</p>
 				</section>
@@ -2763,7 +2764,7 @@
 					<h2>Learn more and download a free 30-day trial at <a href="https://jetbrains.com/ruby">
 						www.jetbrains.com/ruby</a></h2>
 					<p>
-						<img src="img/screenshots/rubymine/learn_more_and_download_trial.png"
+						<img data-src="img/screenshots/rubymine/learn_more_and_download_trial.png"
 							 style="box-shadow: none">
 					</p>
 				</section>
@@ -2779,21 +2780,21 @@
 				<section data-product="phpstorm">
 					<h2>Enjoy native support for PHP 5.3–7.2</h2>
 
-					<img class="plain" src="img/screenshots/phpstorm/php7_2_2.png">
+					<img class="plain" data-src="img/screenshots/phpstorm/php7_2_2.png">
 
 				</section>
 
 				<section data-product="phpstorm">
 					<h2>Do more by typing less with smart code completion</h2>
 
-					<video class = "stretch" data-autoplay src="img/screenshots/phpstorm/completion7.mp4"/>
+					<video class = "stretch" data-autoplay data-src="img/screenshots/phpstorm/completion7.mp4"/>
 
 				</section>
 
 				<section data-product="phpstorm">
 
 					<h2>Navigate around the project efficiently</h2>
-					<video class ="stretch" data-autoplay src="img/screenshots/phpstorm/search8.mp4"/>
+					<video class ="stretch" data-autoplay data-src="img/screenshots/phpstorm/search8.mp4"/>
 				</section>
 
 				<section class="high-image-inside"
@@ -2801,22 +2802,21 @@
 					<h2>Detect errors in advance with built-in inspections</h2>
 					<div class="image-col">
 						<img class="plain"
-							 src="img/screenshots/phpstorm/inspection6.png">
+							 data-src="img/screenshots/phpstorm/inspection6.png">
 					</div>
 				</section>
 
 				<section class="high-image-inside" data-product="phpstorm">
 					<h2>And fix them in no time</h2>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/phpstorm/quickfix6.png">
+						<img class="plain" data-src="img/screenshots/phpstorm/quickfix6.png">
 					</div>
 				</section>
 
 				<section class = "high-image-inside" data-product="phpstorm">
 					<h2>Tidy up your code with built-in coding styles</h2>
 					<div class="image-col">
-						<img
-								src="img/screenshots/phpstorm/codestyle.png"/>
+						<img data-src="img/screenshots/phpstorm/codestyle.png"/>
 					</div>
 				</section>
 
@@ -2824,21 +2824,21 @@
 					<h2>Refactor your code with ease</h2>
 
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/phpstorm/refactor.png">
+						<img class="plain" data-src="img/screenshots/phpstorm/refactor.png">
 					</div>
 				</section>
 
 				<section class="high-image-inside" data-product="phpstorm">
 					<h2>See parameters’ names directly in a call</h2>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/phpstorm/paramhints.png">
+						<img class="plain" data-src="img/screenshots/phpstorm/paramhints.png">
 					</div>
 				</section>
 
 				<section  data-product="phpstorm">
 					<h2>Use Composer integration</h2>
 					<div class="image-col">
-						<img src="img/screenshots/phpstorm/composer.png"/>
+						<img data-src="img/screenshots/phpstorm/composer.png"/>
 					</div>
 				</section>
 
@@ -2846,14 +2846,14 @@
 					<h2>Test your code with popular frameworks</h2>
 					<p>PHPUnit, PHPSpec, Behat, Codeception</p>
 
-					<video class="stretch" data-autoplay src="img/screenshots/phpstorm/phpunit-3.mp4"/>
+					<video class="stretch" data-autoplay data-src="img/screenshots/phpstorm/phpunit-3.mp4"/>
 
 				</section>
 
 				<section class="high-image-inside" data-product="phpstorm">
 					<h2>Debug your application</h2>
 					<div class="image-col">
-						<img src="img/screenshots/phpstorm/Debugger.png"/>
+						<img data-src="img/screenshots/phpstorm/Debugger.png"/>
 					</div>
 				</section>
 
@@ -2861,22 +2861,22 @@
 					<h2>Run your code anywhere</h2>
 					<p>SSH, Vagrant, Docker, Docker Composer</p>
 					<div class="image-col">
-						<img src="img/screenshots/phpstorm/docker_compose_upd.png"/>
+						<img data-src="img/screenshots/phpstorm/docker_compose_upd.png"/>
 					</div>
 				</section>
 
 				<section data-product="phpstorm">
 					<h2>Enjoy PHP frameworks support</h2>
 					<ul class="slide-block">
-						<li><img class="slide-logo-medium" src="img/screenshots/phpstorm/logos/symfony_black_03.png"></li>
-						<li><img class="slide-logo-medium" src="img/screenshots/phpstorm/logos/druplicon-small.png"></li>
-						<li><img class="slide-logo-medium" src="img/screenshots/phpstorm/logos/Wordpress-Logo.svg.png"></li>
-						<li><img class="slide-logo-medium" src="img/screenshots/phpstorm/logos/laravel.svg"></li>
-						<li><img class="slide-logo-medium" src="img/screenshots/phpstorm/logos/joomla.png"></li>
-						<li><img class="slide-logo-medium" src="img/screenshots/phpstorm/logos/magento.png"></li>
-						<li><img class="slide-logo-medium" src="img/screenshots/phpstorm/logos/cakephp.svg"></li>
-						<li><img class="slide-logo-medium" src="img/screenshots/phpstorm/logos/zend-framework.svg"></li>
-						<li><img class="slide-logo-medium" src="img/screenshots/phpstorm/logos/yii.png"></li>
+						<li><img class="slide-logo-medium" data-src="img/screenshots/phpstorm/logos/symfony_black_03.png"></li>
+						<li><img class="slide-logo-medium" data-src="img/screenshots/phpstorm/logos/druplicon-small.png"></li>
+						<li><img class="slide-logo-medium" data-src="img/screenshots/phpstorm/logos/Wordpress-Logo.svg.png"></li>
+						<li><img class="slide-logo-medium" data-src="img/screenshots/phpstorm/logos/laravel.svg"></li>
+						<li><img class="slide-logo-medium" data-src="img/screenshots/phpstorm/logos/joomla.png"></li>
+						<li><img class="slide-logo-medium" data-src="img/screenshots/phpstorm/logos/magento.png"></li>
+						<li><img class="slide-logo-medium" data-src="img/screenshots/phpstorm/logos/cakephp.svg"></li>
+						<li><img class="slide-logo-medium" data-src="img/screenshots/phpstorm/logos/zend-framework.svg"></li>
+						<li><img class="slide-logo-medium" data-src="img/screenshots/phpstorm/logos/yii.png"></li>
 					</ul>
 				</section>
 
@@ -2884,7 +2884,7 @@
 				<section class="high-image-inside" data-product="phpstorm">
 					<h2>Commit, review diffs and resolve conflicts</h2>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/webstorm/vcs-diff.png">
+						<img class="plain" data-src="img/screenshots/webstorm/vcs-diff.png">
 					</div>
 				</section>
 
@@ -2892,27 +2892,27 @@
 						 data-product="phpstorm">
 					<h2>Work with Databases and SQL Editor</h2>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/datagrip/ModifyTable.png">
+						<img class="plain" data-src="img/screenshots/datagrip/ModifyTable.png">
 					</div>
 				</section>
 				<section data-product="phpstorm">
 					<h2>Get top-notch Web Technologies support</h2>
 					<ul class="slide-block">
-						<li><img class="slide-logo-small" src="img/external_logos/javascript.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/css3.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/html5.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/typescript.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/dart.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/flow.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/ecmascript6.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/less.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/sass.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/react.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/angularjs-notext.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/vuejs.svg" alt=""></li>
-						<li><img class="slide-logo-small" src="img/external_logos/nodejs.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/jest.svg"></li>
-						<li><img class="slide-logo-small" src="img/external_logos/ionic.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/javascript.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/css3.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/html5.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/typescript.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/dart.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/flow.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/ecmascript6.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/less.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/sass.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/react.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/angularjs-notext.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/vuejs.svg" alt=""></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/nodejs.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/jest.svg"></li>
+						<li><img class="slide-logo-small" data-src="img/external_logos/ionic.svg"></li>
 					</ul>
 				</section>
 
@@ -2934,7 +2934,7 @@
 					<h2>Compose and run HTTP requests in the editor</h2>
 					<p>Support for environment variables, diff, code completion, and VCS integration</p>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/phpstorm/rest_editor.png">
+						<img class="plain" data-src="img/screenshots/phpstorm/rest_editor.png">
 					</div>
 				</section>
 
@@ -2942,7 +2942,7 @@
 						 data-product="phpstorm">
 					<h2>Catch unhandled exceptions</h2>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/phpstorm/unhandled_exception.png">
+						<img class="plain" data-src="img/screenshots/phpstorm/unhandled_exception.png">
 					</div>
 				</section>
 
@@ -2950,7 +2950,7 @@
 						 data-product="phpstorm">
 					<h2>Create Codeception and PHPSpec tests</h2>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/phpstorm/codeception.png">
+						<img class="plain" data-src="img/screenshots/phpstorm/codeception.png">
 					</div>
 				</section>
 
@@ -2958,7 +2958,7 @@
 						 data-product="phpstorm">
 					<h2>Use JS code completion in Twig templates</h2>
 					<div class="image-col">
-						<img class="plain" src="img/screenshots/phpstorm/twig_injection.png">
+						<img class="plain" data-src="img/screenshots/phpstorm/twig_injection.png">
 					</div>
 				</section>
 
@@ -2982,35 +2982,35 @@
                                 <section class="high-image-inside" data-product="phpstorm">
                                     <h2>Enjoy completion for Hook declaration</h2>
                                     <div class="image-col">
-                                        <img class="plain" src="img/screenshots/phpstorm/hookcompletion.png">
+                                        <img class="plain" data-src="img/screenshots/phpstorm/hookcompletion.png">
                                     </div>
                                 </section>
 
                                 <section data-product="phpstorm">
                                     <h2>Easily navigate to all hook implementations</h2>
 
-                                    <video class="stretch" data-autoplay src="img/screenshots/phpstorm/hooknav2.mp4"></video>
+                                    <video class="stretch" data-autoplay data-src="img/screenshots/phpstorm/hooknav2.mp4"></video>
 
                                 </section>
 
                                 <section class="high-image-inside" data-product="phpstorm">
                                     <h2>See quick documentation for Hook declaration</h2>
                                     <div class="image-col">
-                                        <img class="plain" src="img/screenshots/phpstorm/hookQuickDoc.png">
+                                        <img class="plain" data-src="img/screenshots/phpstorm/hookQuickDoc.png">
                                     </div>
                                 </section>
 
                                 <section class="high-image-inside" data-product="phpstorm">
                                     <h2>Get full Symfony support</h2>
                                     <div class="image-col">
-                                        <img class="plain" src="img/screenshots/phpstorm/drupalsymf.png">
+                                        <img class="plain" data-src="img/screenshots/phpstorm/drupalsymf.png">
                                     </div>
                                 </section>
 
                                 <section class="high-image-inside" data-product="phpstorm">
                                     <h2>Keep code neat with Drupal Coder integration</h2>
                                     <div class="image-col">
-                                        <img class="plain" src="img/screenshots/phpstorm/drupalCoder.png">
+                                        <img class="plain" data-src="img/screenshots/phpstorm/drupalCoder.png">
                                     </div>
                                 </section>
 
@@ -3018,7 +3018,7 @@
                                     <h2>Check out Drupal Symfony Bridge plugin (external)</h2>
                                     <p>Integrates support for Symfony components in Drupal 8 with Symfony Plugin</p>
                                     <div class="image-col">
-                                        <img class="plain" src="img/screenshots/phpstorm/bridge.png">
+                                        <img class="plain" data-src="img/screenshots/phpstorm/bridge.png">
                                     </div>
                                 </section>
                                 -->


### PR DESCRIPTION
This PR enables lazy loading of images and videos. If we use the `src` attribute for images and videos, then the browser will load ALL images and videos at startup, even for slideshows that aren't enabled. But if we use the `data-src` attribute, then the images are lazy loaded, as the slideshow plays.